### PR TITLE
fixes production issue where the map was not served

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,8 @@ The map lives here: http://energy.gov/indianenergy/tribal-energy-projects-map
 It appears that `browsersync`, which is used to reload and serve the files for local developement may do some light parsing of html files (ignoring trailing slashes, etc.) that does not happen in production. So, if you're noticing a bug that's appearing in production but you can't seem to reproduce locally with `gulp watch`, try reproducing the production environment by
 
 1. running `gulp build`
-2. instead of going to port 3000 to view the map, open `[path]/eere-ie-projects-map/dist/index.html`
-3. open the browser console
+2. cd into `/dist`
+3. run `python3 -m http.server`
+4. go to `localhost:8000`
+5. open the browser console
 

--- a/readme.md
+++ b/readme.md
@@ -45,3 +45,11 @@ This task will run a build step, write the results to a `.publish` folder (which
 ### In the wild
 The map lives here: http://energy.gov/indianenergy/tribal-energy-projects-map
 
+### Debugging in production
+
+It appears that `browsersync`, which is used to reload and serve the files for local developement may do some light parsing of html files (ignoring trailing slashes, etc.) that does not happen in production. So, if you're noticing a bug that's appearing in production but you can't seem to reproduce locally with `gulp watch`, try reproducing the production environment by
+
+1. running `gulp build`
+2. instead of going to port 3000 to view the map, open `[path]/eere-ie-projects-map/dist/index.html`
+3. open the browser console
+

--- a/src/client/js/app.es6.js
+++ b/src/client/js/app.es6.js
@@ -207,7 +207,6 @@ import GeoJSON from './geojson.min.js';
     geojsondata.features = geojsondata.features.filter((feat) =>
       filterData(feat, config.uiFilters)
     );
-    console.log(geojsondata.features);
 
     map.getSource("locations").setData(geojsondata);
     zoomMapBounds(geojsondata.features, config);

--- a/src/index.html
+++ b/src/index.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Indian Energy Projects Map</title>
-    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet" media="all">
+    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet" media="all">
 
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css" rel="stylesheet" media="all">
+    <link href="//cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css" rel="stylesheet" media="all">
 
     <link href='https://api.mapbox.com/mapbox-gl-js/v2.0.0/mapbox-gl.css' rel='stylesheet' media="all"/>
 
@@ -85,16 +85,16 @@
 
 
 <!-- Libraries -->
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
 
 <script src='https://api.mapbox.com/mapbox-gl-js/v2.0.0/mapbox-gl.js'></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.4.2/tabletop.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.4.2/tabletop.min.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/jquery.dataTables.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/dataTables.bootstrap.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/jquery.dataTables.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/dataTables.bootstrap.min.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/3.0.3/handlebars.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/3.0.3/handlebars.min.js"></script>
 <!-- End Libraries -->
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Indian Energy Projects Map</title>
-    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet" media="all">
+    <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.0.2/css/bootstrap.min.css" rel="stylesheet" media="all">
 
-    <link href="//cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css" rel="stylesheet" media="all">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/css/dataTables.bootstrap.min.css" rel="stylesheet" media="all">
 
     <link href='https://api.mapbox.com/mapbox-gl-js/v2.0.0/mapbox-gl.css' rel='stylesheet' media="all"/>
 
@@ -85,16 +85,16 @@
 
 
 <!-- Libraries -->
-<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.0.2/js/bootstrap.min.js"></script>
 
 <script src='https://api.mapbox.com/mapbox-gl-js/v2.0.0/mapbox-gl.js'></script>
 
-<script src="//cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.4.2/tabletop.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/tabletop.js/1.4.2/tabletop.min.js"></script>
 
-<script src="//cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/jquery.dataTables.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/dataTables.bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/jquery.dataTables.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.10/js/dataTables.bootstrap.min.js"></script>
 
-<script src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/3.0.3/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/3.0.3/handlebars.min.js"></script>
 <!-- End Libraries -->
 
 
@@ -125,7 +125,7 @@
 
 <!-- build:js client/js/app.min.js -->
 
-<script src="/client/js/bundle.js"></script>
+<script src="client/js/bundle.js"></script>
 
 <!-- endbuild -->
 


### PR DESCRIPTION
It appears that browsersync does some light parsing of html when running locally that we wouldn't get in production, so when I ran `gulp deploy` and opened `.publish/index.html` in the browser the map wouldn't appear and there were a bunch of console errors about invalid urls. I went through and fixed those urls, ran `gulp deploy` again and opened `.publsih/index.html` in the browser and the map appeared with no console errors.